### PR TITLE
Fix #30 #34 #35 #36, and minor changes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function EachMapReset() {
     SkipMapReset();
     MapTimeout = false;
 }
-function CheckMod(IfOutput){
+async function CheckMod(IfOutput){
   await lobby.updateSettings();
             CheckPass = true;
             for (const w of lobby.slots)
@@ -129,7 +129,7 @@ function TryNextMap() {
 
     }
 }
-function syncStatus() {
+async function syncStatus() {
     await lobby.updateSettings();
     playersLeftToJoin = match.teams.length;
     for (const q of match.teams) {
@@ -316,7 +316,7 @@ function createListeners() {
           }
       }
   });
-  lobby.on("playerLeft",()=> {
+  lobby.on("playerLeft",async()=> {
       await lobby.updateSettings();
       let Found = false;
       let LeftName = "???";
@@ -346,11 +346,10 @@ function createListeners() {
                   if (AbortMap.has(LeftName) || AbortMap.get(LeftName)) {
                       AbortMap.set(LeftName, false);
                       lobby.abortMatch();
-                      ready = false;
+                      //ready = false;
                       channel.sendMessage(`Match aborted due to early disconnect because of ${LeftName}`);
                       channel.sendMessage(`${LeftName} used his/her abort chance`);
                   }
-                  break;
               }
           
       
@@ -458,8 +457,8 @@ function createListeners() {
                     CheckMod(false);
                     break;
                 case 'map':
-                    const TMapId = MapMap.get(m[1]) || -1;
-                    const TRound = m[2];
+                    let TMapId = MapMap.get(m[1]) || -1;
+                    let TRound = m[2];
                     if (TMapId == -1) {
                         channel.sendMessage(`图池代码不存在!`);
                         break;
@@ -483,8 +482,8 @@ function createListeners() {
                     channel.sendMessage(`使用>mod 查看所有人mod(log)`);
                     break;
                 case 'map':
-                    const TMapId = MapMap.get(m[1]) || -1;
-                    const TRound = m[2];
+                    let TMapId = MapMap.get(m[1]) || -1;
+                    let TRound = m[2];
                     if (TMapId == -1) {
                         channel.sendMessage(`图池代码不存在!`);
                         break;


### PR DESCRIPTION
将检查mod合法性的功能整合到一个函数里
防止有人在准备后利用延迟开启非法mod
在restart时记录log内容
新增xiaobaidan特供服务
添加StatusLock以锁定状态以防在敏感时段skip
重启后重新检测playersLeftToJoin
添加#hyw
在选手离开又进场时可以继续比赛而不需要>auto on启动
说话更接近osu!一些

To integrate mod illegal status to one function
Fix #30 that someone changed their mod during the interval where !mp settings !mp start 10 is sent.
Make console log when writing into Restart.json
Send special message when xiaobaidan leave
Add StatusLock variable to prevent skipping on unexpected occasions (eg game ends. Everyone is ready, check if everyone has the correct mod, then start) Fix #35  .
Detect playersLeftToJoin after restarting Fix #34 
Add `#hyw` Fix #36 
Modify poke text.

Known bug: The bot might crash if the game is forced start AND `#skip` is sent after !mp start 15