### PR TITLE
Remove unused limiterPublic config option

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -7,7 +7,6 @@
 	"userId": 0,
 	"limiterTimespan": 6000,
 	"limiterPrivate": 4,
-	"limiterPublic": 3,
 	"discord" : {
 		"webhookLink" : "",
 		"refereeRole": 0


### PR DESCRIPTION
The 'limiterPublic' field was removed from config.example.json, since bancho.js no longer uses this.