### PR TITLE
Fix unknown command logging in argument parser

### DIFF
--- a/main.js
+++ b/main.js
@@ -89,7 +89,7 @@ if (process.argv.length > 2) {
                 auto = false;
                 break;
             default:
-                SendLogToRanderer(`Unknown command ${process.argv[2]}!`);
+                SendLogToRanderer(`Unknown command ${process.argv[i]}!`); 
                 process.exit(1);
         }
 }


### PR DESCRIPTION
Corrects the log message to display the actual unknown command by referencing the current argument index instead of a hardcoded value.